### PR TITLE
Improve Docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,16 @@
+.git
+.gitignore
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+.build/
+dist/
+.wheels/
+.cache/
+.env
+*.log
+.mypy_cache/
+.pytest_cache/
+.vscode/
+.idea/

--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,6 @@
 # Docker Image Settings
 IMAGE_NAME=uigf-api
 CONTAINER_NAME=UIGF-API
-IMAGE_TAG=2.0
-EXTERNAL_PORT=3052
 
 # App Settings
 TOKEN=AppToken

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,44 @@
-#!/bin/sh
-# Build Stage
+# syntax=docker/dockerfile:1.6
+
+
+# Build stage
 FROM python:3.12 AS builder
 WORKDIR /code
-ADD . /code
-RUN pip install "fastapi[standard]"
-RUN pip install redis
-RUN pip install sqlalchemy
-RUN pip install pymysql
-RUN pip install "sentry-sdk[fastapi]"
-RUN pip install cryptography
-RUN pip install pyinstaller
-RUN pyinstaller -F main.py
 
-# Runtime
+# Use --mount=type=cache to cache pip downloads between builds
+COPY requirements.txt /code/requirements.txt
+RUN --mount=type=cache,target=/root/.cache/pip,id=pip-cache \
+    python -m pip install --upgrade pip wheel \
+ && pip wheel -r requirements.txt -w /wheels
+
+# Coyp source code
+COPY . /code
+
+# Install dependencies from wheels cache (offline installation)
+RUN --mount=type=cache,target=/root/.cache/pip,id=pip-cache \
+    pip install --no-index --find-links=/wheels -r requirements.txt
+
+# Run PyInstaller to create a single executable
+RUN --mount=type=cache,target=/root/.cache/pip,id=pip-cache \
+    pip install --no-index --find-links=/wheels pyinstaller \
+ && pyinstaller -F main.py
+
+
+# Runtime stage
 FROM ubuntu:24.04 AS runtime
 WORKDIR /app
-COPY --from=builder /code/dist/main .
-EXPOSE 8000
-ENTRYPOINT ["./main"]
+
+# Install runner dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      ca-certificates \
+ && rm -rf /var/lib/apt/lists/*
+
+# Copy the built executable from the builder stage
+COPY --from=builder /code/dist/main /app/main
+
+# Health check
+# HEALTHCHECK --interval=30s --timeout=3s --start-period=10s --retries=3 \
+#   CMD curl -fsS http://localhost:8080/health || exit 1
+
+EXPOSE 8080
+ENTRYPOINT ["/app/main"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,16 +7,19 @@ WORKDIR /code
 
 # Use --mount=type=cache to cache pip downloads between builds
 COPY requirements.txt /code/requirements.txt
+COPY requirements.build.txt /code/requirements.build.txt
 RUN --mount=type=cache,target=/root/.cache/pip,id=pip-cache \
     python -m pip install --upgrade pip wheel \
- && pip wheel -r requirements.txt -w /wheels
+ && pip wheel -r requirements.txt -w /wheels \
+ && pip wheel -r requirements.build.txt -w /wheels
 
 # Coyp source code
 COPY . /code
 
 # Install dependencies from wheels cache (offline installation)
 RUN --mount=type=cache,target=/root/.cache/pip,id=pip-cache \
-    pip install --no-index --find-links=/wheels -r requirements.txt
+    pip install --no-index --find-links=/wheels -r requirements.txt \
+ && pip install --no-index --find-links=/wheels -r requirements.build.txt
 
 # Run PyInstaller to create a single executable
 RUN --mount=type=cache,target=/root/.cache/pip,id=pip-cache \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
 # syntax=docker/dockerfile:1.6
 
-
 # Build stage
 FROM python:3.12 AS builder
 WORKDIR /code
@@ -43,5 +42,4 @@ COPY --from=builder /code/dist/main /app/main
 # HEALTHCHECK --interval=30s --timeout=3s --start-period=10s --retries=3 \
 #   CMD curl -fsS http://localhost:8080/health || exit 1
 
-EXPOSE 8080
 ENTRYPOINT ["/app/main"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,8 +22,7 @@ RUN --mount=type=cache,target=/root/.cache/pip,id=pip-cache \
 
 # Run PyInstaller to create a single executable
 RUN --mount=type=cache,target=/root/.cache/pip,id=pip-cache \
-    pip install --no-index --find-links=/wheels pyinstaller \
- && pyinstaller -F main.py
+    pyinstaller -F main.py
 
 
 # Runtime stage

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN --mount=type=cache,target=/root/.cache/pip,id=pip-cache \
  && pip wheel -r requirements.txt -w /wheels \
  && pip wheel -r requirements.build.txt -w /wheels
 
-# Coyp source code
+# Copy source code
 COPY . /code
 
 # Install dependencies from wheels cache (offline installation)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
     volumes:
       - ./cache:/app/cache
       - ./dict:/app/dict
-      - ./.env:/app/.env
+      - ./.env:/app/.env:ro
     restart: unless-stopped
     depends_on:
       - tunnel

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,10 +6,8 @@ services:
       context: .
       dockerfile: Dockerfile
       target: runtime
-    image: ${IMAGE_NAME}:${IMAGE_TAG}
+    image: ${IMAGE_NAME}:latest
     container_name: ${CONTAINER_NAME}-Server
-    ports:
-      - "${EXTERNAL_PORT}:8080"
     volumes:
       - ./cache:/app/cache
       - ./dict:/app/dict

--- a/requirements.build.txt
+++ b/requirements.build.txt
@@ -1,0 +1,1 @@
+pyinstaller==6.10.0

--- a/requirements.build.txt
+++ b/requirements.build.txt
@@ -1,2 +1,3 @@
 pyinstaller==6.10.0
+# setuptools is pinned below version 81 due to incompatibility with PyInstaller; see https://github.com/pyinstaller/pyinstaller/issues/7994
 setuptools<81

--- a/requirements.build.txt
+++ b/requirements.build.txt
@@ -1,1 +1,2 @@
 pyinstaller==6.10.0
+setuptools<81


### PR DESCRIPTION
Added a .dockerignore file to exclude unnecessary files from Docker context. Refactored Dockerfile to use multi-stage builds, pip cache, and offline wheel installation for faster and more reliable builds. Updated docker-compose.yml to mount .env as read-only.
This pull request introduces several improvements to the project's Docker setup, focusing on optimizing the Docker build process, improving dependency caching, and enhancing the development environment configuration. The changes also include updates to the `.env.example` and `docker-compose.yml` files to streamline deployment and environment management.

**Docker build and environment improvements:**

*Major Dockerfile optimizations:*
- Refactored the `Dockerfile` to use multi-stage builds, add pip caching for faster builds, separate dependency installation using wheels, and ensure a cleaner runtime image. Also added a health check placeholder and improved the executable build process with PyInstaller. (#[DockerfileL1-R45](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L1-R45))

*Dependency management:*
- Added `pyinstaller` and pinned `setuptools` in `requirements.build.txt` to ensure consistent builds. (#[requirements.build.txtR1-R2](diffhunk://#diff-cf36a03be8f5f95e13d523b596b9c216016e93eb278db7a96ea8f0315780b9e8R1-R2))

*Development environment and deployment configuration:*
- Introduced a `.dockerignore` file to exclude unnecessary files from Docker build context, improving build performance and reducing image size. (#[.dockerignoreR1-R16](diffhunk://#diff-2f754321d62f08ba8392b9b168b83e24ea2852bb5d815d63e767f6c3d23c6ac5R1-R16))
- Updated `docker-compose.yml` to use the `latest` tag for the image, mount the `.env` file as read-only, and remove explicit port mapping (now handled elsewhere or by default). (#[docker-compose.ymlL9-R14](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L9-R14))
- Cleaned up `.env.example` by removing unused variables related to image tagging and external port mapping. (#[.env.exampleL4-L5](diffhunk://#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8cL4-L5))